### PR TITLE
extern C inside header file

### DIFF
--- a/mapcodelib/mapcoder.h
+++ b/mapcodelib/mapcoder.h
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define mapcode_cversion "2.0.2"
 
 #define UWORD                               unsigned short int  // 2-byte unsigned integer.
@@ -314,3 +319,7 @@ const UWORD *encodeToAlphabet(const char *string, int alphabet);
 #define MAPCODE_LANGUAGE_BENGALI       MAPCODE_ALPHABET_BENGALI
 #define MAPCODE_LANGUAGE_GURMUKHI      MAPCODE_ALPHABET_GURMUKHI
 #define MAPCODE_LANGUAGE_TIBETAN       MAPCODE_ALPHABET_TIBETAN
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
C++ compilers require that C functions are declared inside an extern "C" { } scope. This stops the compiler mangling the names, which would cause link errors. This pull request adds those into the header file, conditionally if __cplusplus is defined. All C++ compilers do define this symbol when they are compiling C++.
